### PR TITLE
Add emulator skeleton with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # x86-Emulator
+
+A Python-based x86 assembly emulator with an interactive CLI.
+
+See `docs/commands.md` for available commands.

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI package for emulator."""

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,0 +1,91 @@
+"""Command line interface for the emulator."""
+
+from __future__ import annotations
+
+import argparse
+import cmd
+import shlex
+from typing import List
+
+from emulator.loader import load_file
+from emulator.core import CPUState
+from emulator.debugger import Debugger
+from emulator.utils import parse_number, to_hex
+
+
+class EmulatorShell(cmd.Cmd):
+    intro = "x86 Emulator. Type help or ? to list commands."
+    prompt = "(emu) "
+
+    def __init__(self, dbg: Debugger):
+        super().__init__()
+        self.dbg = dbg
+
+    def do_next(self, arg: str) -> bool:
+        """Execute next instruction."""
+        self.dbg.step()
+        print(self.dbg.cpu.instructions[self.dbg.cpu.regs["EIP"] - 1]["text"])
+        return False
+
+    do_n = do_next
+
+    def do_cont(self, arg: str) -> bool:
+        """Continue execution."""
+        self.dbg.continue_run()
+        return False
+
+    do_c = do_cont
+
+    def do_regs(self, arg: str) -> bool:
+        regs = self.dbg.dump_registers()
+        for k, v in regs.items():
+            print(f"{k}: {to_hex(v)}")
+        return False
+
+    def do_stack(self, arg: str) -> bool:
+        words = int(arg) if arg else 4
+        stack = self.dbg.dump_stack(words)
+        for i, val in enumerate(stack):
+            print(f"{i*4:04x}: {to_hex(val)}")
+        return False
+
+    def do_break(self, arg: str) -> bool:
+        addr = parse_number(arg) if arg.isdigit() or arg.startswith("0x") else self.dbg.cpu.labels.get(arg, 0)
+        self.dbg.add_breakpoint(addr)
+        print(f"Breakpoint set at {addr}")
+        return False
+
+    do_b = do_break
+
+    def do_set(self, arg: str) -> bool:
+        parts = shlex.split(arg)
+        if len(parts) != 2:
+            print("usage: set REG VALUE")
+            return False
+        reg, val = parts
+        self.dbg.cpu.regs[reg.upper()] = parse_number(val)
+        return False
+
+    def do_quit(self, arg: str) -> bool:
+        return True
+
+    do_q = do_quit
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="x86 emulator")
+    parser.add_argument("file", help="assembly file to emulate")
+    args = parser.parse_args(argv)
+
+    data = load_file(args.file)
+    cpu = CPUState()
+    cpu.instructions = data["instructions"]
+    cpu.labels = data["labels"]
+
+    dbg = Debugger(cpu)
+    shell = EmulatorShell(dbg)
+    shell.cmdloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,15 @@
+# Emulator CLI Commands
+
+Use `emu-cli <file>` to start an interactive session.
+
+Commands:
+
+- `n` or `next`: execute the next instruction
+- `c` or `cont`: continue execution until the next breakpoint or end
+- `b <addr|label>`: set a breakpoint
+- `regs`: display registers
+- `stack [n]`: display `n` words from the stack (default 4)
+- `set <reg> <value>`: set register `reg` to `value`
+- `quit` or `q`: exit the emulator
+
+Invoke `emu-cli --help` for command-line options.

--- a/emul.asm
+++ b/emul.asm
@@ -1,0 +1,6 @@
+start:
+    MOV EAX, 1
+    MOV EBX, 2
+    ADD EAX, EBX
+    CALL printf
+    MOV ECX, EAX

--- a/emulator/__init__.py
+++ b/emulator/__init__.py
@@ -1,0 +1,7 @@
+"""x86 Emulator package."""
+
+from .core import CPUState
+from .loader import load_file
+from .debugger import Debugger
+
+__all__ = ["CPUState", "load_file", "Debugger"]

--- a/emulator/conventions.py
+++ b/emulator/conventions.py
@@ -1,0 +1,30 @@
+"""Simple calling convention stubs."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .core import CPUState
+
+
+EXTERNAL_CALLS: Dict[str, Callable[[CPUState], None]] = {}
+
+
+def register_call(name: str, func: Callable[[CPUState], None]) -> None:
+    EXTERNAL_CALLS[name.lower()] = func
+
+
+def handle_call(cpu: CPUState, name: str) -> None:
+    func = EXTERNAL_CALLS.get(name.lower())
+    if func:
+        func(cpu)
+    else:
+        print(f"[warn] no handler for external function '{name}'")
+
+
+def printf_stub(cpu: CPUState) -> None:
+    print("[stub] printf called")
+    cpu.regs["EAX"] = 0
+
+
+register_call("printf", printf_stub)

--- a/emulator/core.py
+++ b/emulator/core.py
@@ -1,0 +1,52 @@
+"""Core CPU state and memory model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+MEMORY_SIZE = 1024 * 1024  # 1 MB for demos
+STACK_SIZE = 0x1000
+STACK_BASE = MEMORY_SIZE - STACK_SIZE
+
+
+@dataclass
+class CPUState:
+    regs: Dict[str, int] = field(default_factory=lambda: {
+        "EAX": 0,
+        "EBX": 0,
+        "ECX": 0,
+        "EDX": 0,
+        "ESI": 0,
+        "EDI": 0,
+        "EBP": 0,
+        "ESP": STACK_BASE,
+        "EIP": 0,
+        "EFLAGS": 0,
+    })
+    memory: bytearray = field(default_factory=lambda: bytearray(MEMORY_SIZE))
+    labels: Dict[str, int] = field(default_factory=dict)
+    instructions: List[Dict] = field(default_factory=list)
+
+    def push(self, value: int) -> None:
+        self.regs["ESP"] -= 4
+        self._write_dword(self.regs["ESP"], value)
+
+    def pop(self) -> int:
+        value = self._read_dword(self.regs["ESP"])
+        self.regs["ESP"] += 4
+        return value
+
+    def _write_dword(self, addr: int, value: int) -> None:
+        self.memory[addr:addr+4] = value.to_bytes(4, "little")
+
+    def _read_dword(self, addr: int) -> int:
+        return int.from_bytes(self.memory[addr:addr+4], "little")
+
+    def fetch_instruction(self) -> Dict:
+        try:
+            ins = self.instructions[self.regs["EIP"]]
+        except IndexError:
+            raise StopIteration("EIP out of range")
+        self.regs["EIP"] += 1
+        return ins

--- a/emulator/debugger.py
+++ b/emulator/debugger.py
@@ -1,0 +1,48 @@
+"""Debugger and execution engine."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+from .core import CPUState
+from .instructions import INSTRUCTION_SET
+from .conventions import handle_call
+
+
+class Debugger:
+    def __init__(self, cpu: CPUState) -> None:
+        self.cpu = cpu
+        self.breakpoints: Set[int] = set()
+        self.running = True
+
+    def step(self) -> None:
+        ins = self.cpu.fetch_instruction()
+        op = ins["op"]
+        args = ins["args"]
+        if op == "CALL" and ins["args"][0] not in self.cpu.labels:
+            handle_call(self.cpu, ins["args"][0])
+            return
+        func = INSTRUCTION_SET.get(op)
+        if not func:
+            raise ValueError(f"Unknown instruction: {op}")
+        func(self.cpu, args)
+
+    def continue_run(self) -> None:
+        while self.running:
+            if self.cpu.regs["EIP"] in self.breakpoints:
+                break
+            try:
+                self.step()
+            except StopIteration:
+                self.running = False
+                break
+
+    def add_breakpoint(self, addr: int) -> None:
+        self.breakpoints.add(addr)
+
+    def dump_registers(self) -> Dict[str, int]:
+        return dict(self.cpu.regs)
+
+    def dump_stack(self, words: int = 4) -> List[int]:
+        addr = self.cpu.regs["ESP"]
+        return [self.cpu._read_dword(addr + i * 4) for i in range(words)]

--- a/emulator/instructions.py
+++ b/emulator/instructions.py
@@ -1,0 +1,104 @@
+"""Instruction implementations."""
+
+from __future__ import annotations
+
+from typing import Dict, Callable, List
+
+from .core import CPUState
+from .utils import parse_number
+
+
+InstructionFunc = Callable[[CPUState, List[str]], None]
+
+
+REGISTERS = {
+    "EAX", "EBX", "ECX", "EDX", "ESI", "EDI", "EBP", "ESP", "EIP",
+}
+
+
+def _get_operand_value(cpu: CPUState, op: str) -> int:
+    op = op.upper()
+    if op in cpu.regs:
+        return cpu.regs[op]
+    return parse_number(op)
+
+
+def _set_register(cpu: CPUState, reg: str, value: int) -> None:
+    cpu.regs[reg.upper()] = value & 0xFFFFFFFF
+
+
+def mov(cpu: CPUState, args: List[str]) -> None:
+    dst, src = args
+    value = _get_operand_value(cpu, src)
+    _set_register(cpu, dst, value)
+
+
+def add(cpu: CPUState, args: List[str]) -> None:
+    dst, src = args
+    value = _get_operand_value(cpu, src)
+    _set_register(cpu, dst, (cpu.regs[dst.upper()] + value) & 0xFFFFFFFF)
+
+
+def sub(cpu: CPUState, args: List[str]) -> None:
+    dst, src = args
+    value = _get_operand_value(cpu, src)
+    _set_register(cpu, dst, (cpu.regs[dst.upper()] - value) & 0xFFFFFFFF)
+
+
+def jmp(cpu: CPUState, args: List[str]) -> None:
+    target = args[0]
+    if target in cpu.labels:
+        cpu.regs["EIP"] = cpu.labels[target]
+    else:
+        cpu.regs["EIP"] = _get_operand_value(cpu, target)
+
+
+def cmp(cpu: CPUState, args: List[str]) -> None:
+    a = _get_operand_value(cpu, args[0])
+    b = _get_operand_value(cpu, args[1])
+    cpu.regs["EFLAGS"] = 0
+    if a == b:
+        cpu.regs["EFLAGS"] |= 0x40  # ZF
+
+
+def je(cpu: CPUState, args: List[str]) -> None:
+    if cpu.regs["EFLAGS"] & 0x40:
+        jmp(cpu, args)
+
+
+def jne(cpu: CPUState, args: List[str]) -> None:
+    if not (cpu.regs["EFLAGS"] & 0x40):
+        jmp(cpu, args)
+
+
+def call(cpu: CPUState, args: List[str]) -> None:
+    target = args[0]
+    cpu.push(cpu.regs["EIP"])  # push return addr
+    if target in cpu.labels:
+        cpu.regs["EIP"] = cpu.labels[target]
+    else:
+        # external call stub
+        print(f"[call] external function '{target}'")
+        cpu.pop()  # discard return
+
+
+def ret(cpu: CPUState, args: List[str]) -> None:
+    cpu.regs["EIP"] = cpu.pop()
+
+
+def nop(cpu: CPUState, args: List[str]) -> None:
+    pass
+
+
+INSTRUCTION_SET: Dict[str, InstructionFunc] = {
+    "MOV": mov,
+    "ADD": add,
+    "SUB": sub,
+    "JMP": jmp,
+    "CMP": cmp,
+    "JE": je,
+    "JNE": jne,
+    "CALL": call,
+    "RET": ret,
+    "NOP": nop,
+}

--- a/emulator/loader.py
+++ b/emulator/loader.py
@@ -1,0 +1,30 @@
+"""Load assembly files into instructions."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+INSTRUCTION_RE = re.compile(r"^\s*(?:(?P<label>\w+):)?\s*(?P<op>\w+)?\s*(?P<args>.*)?$")
+
+
+def load_file(filename: str) -> Dict[str, List[Dict]]:
+    instructions: List[Dict] = []
+    labels: Dict[str, int] = {}
+
+    with open(filename, "r") as f:
+        for line in f:
+            line = line.split(";", 1)[0].rstrip()
+            if not line:
+                continue
+            m = INSTRUCTION_RE.match(line)
+            if not m:
+                continue
+            label, op, args = m.group("label", "op", "args")
+            if label is not None:
+                labels[label] = len(instructions)
+            if op:
+                operands = [a.strip() for a in args.split(',')] if args else []
+                instructions.append({"op": op.upper(), "args": operands, "text": line})
+    return {"instructions": instructions, "labels": labels}

--- a/emulator/utils.py
+++ b/emulator/utils.py
@@ -1,0 +1,18 @@
+"""Utility helpers for the emulator."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def to_hex(value: int, width: int = 8) -> str:
+    """Return value formatted as hexadecimal."""
+    return f"0x{value:0{width}X}"
+
+
+def parse_number(text: str) -> int:
+    """Parse a string into an int supporting hex (0x) and decimal."""
+    text = text.strip()
+    if text.startswith("0x"):
+        return int(text, 16)
+    return int(text, 10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click
+pytest

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,1 @@
+pip install -e .

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="x86_emulator",
+    version="0.1.0",
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'emu-cli=cli.main:main',
+        ],
+    },
+)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,7 @@
+from emulator.core import CPUState
+
+
+def test_push_pop():
+    cpu = CPUState()
+    cpu.push(0x12345678)
+    assert cpu.pop() == 0x12345678

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1,0 +1,10 @@
+from emulator.core import CPUState
+from emulator.debugger import Debugger
+
+
+def test_step():
+    cpu = CPUState()
+    cpu.instructions = [{"op": "MOV", "args": ["EAX", "1"], "text": "MOV EAX, 1"}]
+    dbg = Debugger(cpu)
+    dbg.step()
+    assert cpu.regs["EAX"] == 1

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,9 @@
+from emulator.loader import load_file
+
+
+def test_load_file(tmp_path):
+    asm = tmp_path / "test.asm"
+    asm.write_text("""\nstart: MOV EAX, 1\n""")
+    data = load_file(str(asm))
+    assert data["labels"]["start"] == 0
+    assert data["instructions"][0]["op"] == "MOV"


### PR DESCRIPTION
## Summary
- scaffold python emulator package and CLI
- implement minimal CPU state and instruction execution
- add simple debugger with stepping and breakpoints
- document CLI commands
- include install scripts and tests

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b7cad3b483329948d8d3282b1fa1